### PR TITLE
Fix: Update GitHub profile links in Members page

### DIFF
--- a/members.markdown
+++ b/members.markdown
@@ -4,39 +4,38 @@ title: Members
 permalink: /members/
 ---
 
-[![Manas's GitHub stats](https://github-readme-stats.vercel.app/api?username=manasmalla&show_icons=true&border_radius=16&theme=default#gh-light-mode-only)](https://github.com/anuraghazra/github-readme-stats#gh-light-mode-only)
+[![Manas's GitHub stats](https://github-readme-stats.vercel.app/api?username=manasmalla&show_icons=true&border_radius=16&theme=default)](https://github.com/manasmalla)
 
-[![Sampath's GitHub stats](https://github-readme-stats.vercel.app/api?username=sampathbalivada&show_icons=true&border_radius=16&theme=default#gh-light-mode-only)](https://github.com/anuraghazra/github-readme-stats#gh-light-mode-only)
+[![Sampath's GitHub stats](https://github-readme-stats.vercel.app/api?username=sampathbalivada&show_icons=true&border_radius=16&theme=default)](https://github.com/sampathbalivada)
 
-[![Sidharth's GitHub stats](https://github-readme-stats.vercel.app/api?username=psidh&show_icons=true&border_radius=16&theme=default#gh-light-mode-only)](https://github.com/anuraghazra/github-readme-stats#gh-light-mode-only)
+[![Sidharth's GitHub stats](https://github-readme-stats.vercel.app/api?username=psidh&show_icons=true&border_radius=16&theme=default)](https://github.com/psidh)
 
+[![Sumalatha's GitHub stats](https://github-readme-stats.vercel.app/api?username=SumaLatha2023&show_icons=true&border_radius=16&theme=default)](https://github.com/SumaLatha2023)
 
-[![Sumalatha's GitHub stats](https://github-readme-stats.vercel.app/api?username=SumaLatha2023&show_icons=true&border_radius=16&theme=default#gh-light-mode-only)](https://github.com/anuraghazra/github-readme-stats#gh-light-mode-only)
-[![Varshini's GitHub stats](https://github-readme-stats.vercel.app/api?username=varshinisreenivas&show_icons=true&border_radius=16&theme=default#gh-light-mode-only)](https://github.com/anuraghazra/github-readme-stats#gh-light-mode-only)
- [![Hemani's GitHub stats](https://github-readme-stats.vercel.app/api?username=hemani2425&show_icons=true&border_radius=16&theme=default#gh-light-mode-only)](https://github.com/anuraghazra/github-readme-stats#gh-light-mode-only)
+[![Varshini's GitHub stats](https://github-readme-stats.vercel.app/api?username=varshinisreenivas&show_icons=true&border_radius=16&theme=default)](https://github.com/varshinisreenivas)
 
+[![Hemani's GitHub stats](https://github-readme-stats.vercel.app/api?username=hemani2425&show_icons=true&border_radius=16&theme=default)](https://github.com/hemani2425)
 
-[![Lakshmi's GitHub stats](https://github-readme-stats.vercel.app/api?username=lakshmikoyilada&show_icons=true&border_radius=16&theme=default#gh-light-mode-only)](https://github.com/anuraghazra/github-readme-stats#gh-light-mode-only)
+[![Lakshmi's GitHub stats](https://github-readme-stats.vercel.app/api?username=lakshmikoyilada&show_icons=true&border_radius=16&theme=default)](https://github.com/lakshmikoyilada)
 
-[![Asreetha's GitHub stats](https://github-readme-stats.vercel.app/api?username=Asreetha98&show_icons=true&border_radius=16&theme=default#gh-light-mode-only)](https://github.com/anuraghazra/github-readme-stats#gh-light-mode-only)
+[![Asreetha's GitHub stats](https://github-readme-stats.vercel.app/api?username=Asreetha98&show_icons=true&border_radius=16&theme=default)](https://github.com/Asreetha98)
 
-[![chaitanya's GitHub stats](https://github-readme-stats.vercel.app/api?username=Chaitanyakilari&show_icons=true&border_radius=16&theme=default#gh-light-mode-only)](https://github.com/anuraghazra/github-readme-stats#gh-light-mode-only)
+[![Chaitanya's GitHub stats](https://github-readme-stats.vercel.app/api?username=Chaitanyakilari&show_icons=true&border_radius=16&theme=default)](https://github.com/Chaitanyakilari)
 
-[![Mohan's GitHub stats](https://github-readme-stats.vercel.app/api?username=vmss2009&show_icons=true&border_radius=16&theme=default#gh-light-mode-only)](https://github.com/anuraghazra/github-readme-stats#gh-light-mode-only)
+[![Mohan's GitHub stats](https://github-readme-stats.vercel.app/api?username=vmss2009&show_icons=true&border_radius=16&theme=default)](https://github.com/vmss2009)
 
-[![Shaik Shajid]'s GitHub stats](https://github-readme-stats.vercel.app/api?username=shaik-shajid&show_icons=true&border_radius=16&theme=default#gh-light-mode-only)](https://github.com/anuraghazra/github-readme-stats#gh-light-mode-only)
-[![Varshini's GitHub stats](https://github-readme-stats.vercel.app/api?username=varshinisreenivas&show_icons=true&border_radius=16&theme=default#gh-light-mode-only)](https://github.com/anuraghazra/github-readme-stats#gh-light-mode-only)
+[![Shaik Shajid's GitHub stats](https://github-readme-stats.vercel.app/api?username=shaik-shajid&show_icons=true&border_radius=16&theme=default)](https://github.com/shaik-shajid)
 
+[![Dhanush Sai Teja's GitHub stats](https://github-readme-stats.vercel.app/api?username=MUMMIDISETTYDHANUSHSAITEJA&show_icons=true&border_radius=16&theme=default)](https://github.com/MUMMIDISETTYDHANUSHSAITEJA)
 
-[![MUMMIDISETTY DHANUSH SAI TEJA]'s GitHub stats](https://github-readme-stats.vercel.app/api?username=MUMMIDISETTYDHANUSHSAITEJA&show_icons=true&border_radius=16&theme=default#gh-light-mode-only)](https://github.com/anuraghazra/github-readme-stats#gh-light-mode-only)
+[![Hafiza's GitHub stats](https://github-readme-stats.vercel.app/api?username=ShaikHafiza&show_icons=true&border_radius=16&theme=default)](https://github.com/ShaikHafiza)
 
-[![Hafiza's GitHub stats](https://github-readme-stats.vercel.app/api?username=ShaikHafiza&show_icons=true&border_radius=16&theme=default#gh-light-mode-only)](https://github.com/anuraghazra/github-readme-stats#gh-light-mode-only)
+[![Saran's GitHub stats](https://github-readme-stats.vercel.app/api?username=saran-github232&show_icons=true&border_radius=16&theme=default)](https://github.com/saran-github232)
 
-[![chaitanya's GitHub stats](https://github-readme-stats.vercel.app/api?username=Chaitanyakilari&show_icons=true&border_radius=16&theme=default#gh-light-mode-only)](https://github.com/anuraghazra/github-readme-stats#gh-light-mode-only)
+[![Nehal's GitHub stats](https://github-readme-stats.vercel.app/api?username=nehal-5&show_icons=true&border_radius=16&theme=default)](https://github.com/nehal-5)
 
-[![saran]'s GitHub stats](https://github-readme-stats.vercel.app/api?username=saran-github232&show_icons=true&border_radius=16&theme=default#gh-light-mode-only)](https://github.com/anuraghazra/github-readme-stats#gh-light-mode-only)
-[![Nehal]'s GitHub stats](https://github-readme-stats.vercel.app/api?username=nehal-5&show_icons=true&border_radius=16&theme=default#gh-light-mode-only)](https://github.com/anuraghazra/github-readme-stats#gh-light-mode-only)
-
-> To add yourself here copy the following template and replace the X with GitHub Name and x-username with your GitHub username.
+> To add yourself here, copy the following template and replace `your-github-username` with your actual GitHub username:
 >
-> [![X]'s GitHub stats](https://github-readme-stats.vercel.app/api?username=chaitanya&show_icons=true&border_radius=16&theme=default#gh-light-mode-only)](https://github.com/anuraghazra/github-readme-stats#gh-light-mode-only)
+> ```markdown
+> [![Your Name's GitHub stats](https://github-readme-stats.vercel.app/api?username=your-github-username&show_icons=true&border_radius=16&theme=default)](https://github.com/your-github-username)
+> ```


### PR DESCRIPTION

- Changed links to point to individual GitHub profiles instead of the GitHub Readme Stats repository.  
- Improved the contributor template for easier addition of new members.  